### PR TITLE
feat: support more accept header pattern

### DIFF
--- a/$defs.json
+++ b/$defs.json
@@ -209,7 +209,7 @@
         "accept": {
           "description": "application/json, text/plain, */*",
           "type": "string",
-          "pattern": "^(?:([*]|[a-z]+)/([*]|[a-z+\\._-]+)(;q=(1|0|0\\.[0-9]{1,3}))?,? ?)*$",
+          "pattern": "^(?:([*]|[a-z]+)/([*]|[a-z+\\._-]+)(;v=[a-z0-9]+)?(;q=(1|0|0\\.[0-9]{1,3}))?,? ?)*$",
           "maxLength": 256
         },
         "accept-encoding": {


### PR DESCRIPTION
Chrome has additional values in the "Accept" header.

text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7

**;v=b3** was failing.

Used this table from MDN docs as reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Content_negotiation/List_of_default_Accept_values#default_values